### PR TITLE
Loosen rails dependency to be compatible with Rails 4+.

### DIFF
--- a/tablexi_dev-generators.gemspec
+++ b/tablexi_dev-generators.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
-  s.add_dependency "rails", "~> 5.1.4"
+  s.add_dependency "rails", ">= 4.0"
 
   s.add_development_dependency "sqlite3"
 end


### PR DESCRIPTION
We don't appear to be doing anything which requires Rails 5.x, so let's allow
this tool to be installed on Rails 4.x projects