### PR TITLE
reorder the default .rubocop.yml inherit order

### DIFF
--- a/lib/generators/tablexi_dev/rubocop_generator/files/dot_rubocop.yml
+++ b/lib/generators/tablexi_dev/rubocop_generator/files/dot_rubocop.yml
@@ -5,5 +5,5 @@
 # `rails generate tablexi_dev:rubocop`
 inherit_from:
   - .rubocop-txi.yml
-  - .rubocop_todo.yml
   - .rubocop-project_overrides.yml
+  - .rubocop_todo.yml


### PR DESCRIPTION
It should base everything on TXI, then overrides, and only handle the `todo` as last-priority