### PR TITLE
Rubocop 0.53.0 removed the TrailingCommaInLiteral cop.

### DIFF
--- a/lib/generators/tablexi_dev/rubocop_generator/files/dot_rubocop-txi.yml
+++ b/lib/generators/tablexi_dev/rubocop_generator/files/dot_rubocop-txi.yml
@@ -78,7 +78,10 @@ Style/StringLiterals:
 Style/TrailingCommaInArguments:
   EnforcedStyleForMultiline: comma
 
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: comma
+
+Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: comma
 
 Style/TrivialAccessors:


### PR DESCRIPTION
So we replace it with 2 other cops