### PR TITLE
specify the inherit_mode merge for Exclude.

### DIFF
--- a/lib/generators/tablexi_dev/rubocop_generator/files/dot_rubocop.yml
+++ b/lib/generators/tablexi_dev/rubocop_generator/files/dot_rubocop.yml
@@ -7,3 +7,9 @@ inherit_from:
   - .rubocop-txi.yml
   - .rubocop-project_overrides.yml
   - .rubocop_todo.yml
+
+# Allow the list of files Excluded by .rubocop-txi to be merged
+# with files excluded by the .rubocop-project_overrides and .rubocop_todo files
+inherit_mode:
+  merge:
+    - Exclude


### PR DESCRIPTION
This allows our .rubocop-project-overrides to be combined with the .rubocop-txi for the same rule

This is a new feature from rubocop 0.53.0