### PR TITLE
Add a BaseGenerator that all other TablexiDev generators inherit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.gem
 .bundle/
 log/*.log
 pkg/

--- a/lib/generators/tablexi_dev/all_generator.rb
+++ b/lib/generators/tablexi_dev/all_generator.rb
@@ -4,7 +4,7 @@ module TablexiDev
 
   module Generators
 
-    class AllGenerator < Rails::Generators::Base
+    class AllGenerator < BaseGenerator
 
       GENERATORS = %i[
         git_hook

--- a/lib/generators/tablexi_dev/base_generator.rb
+++ b/lib/generators/tablexi_dev/base_generator.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module TablexiDev
+
+  module Generators
+
+    # All other TablexiDev generators should inherit this base generator
+    class BaseGenerator < Rails::Generators::Base
+
+      protected
+
+      def copy_file_and_set_executable(source_file, target_file)
+        copy_file source_file, target_file
+        chmod target_file, 0o755
+      end
+
+    end
+
+  end
+
+end

--- a/lib/generators/tablexi_dev/git_hook_generator.rb
+++ b/lib/generators/tablexi_dev/git_hook_generator.rb
@@ -4,7 +4,7 @@ module TablexiDev
 
   module Generators
 
-    class GitHookGenerator < Rails::Generators::Base
+    class GitHookGenerator < BaseGenerator
 
       source_root File.expand_path("../git_hook_generator/files/", __FILE__)
 
@@ -23,8 +23,8 @@ module TablexiDev
         general_path = ".git/hooks/pre-#{type}"
 
         # Copy files from this generator into the project
-        copy_file "rubocop-pre-#{type}", rubocop_path
-        copy_file "general-pre-#{type}", general_path unless File.exist?(general_path)
+        copy_file_and_set_executable "rubocop-pre-#{type}", rubocop_path
+        copy_file_and_set_executable "general-pre-#{type}", general_path unless File.exist?(general_path)
 
         # Ensure we do not append to the general hook file more than once
         unless File.readlines(general_path).grep(/rubocop-pre-#{type}/).size > 0

--- a/lib/generators/tablexi_dev/rubocop_generator.rb
+++ b/lib/generators/tablexi_dev/rubocop_generator.rb
@@ -4,7 +4,7 @@ module TablexiDev
 
   module Generators
 
-    class RubocopGenerator < Rails::Generators::Base
+    class RubocopGenerator < BaseGenerator
 
       source_root File.expand_path("../rubocop_generator/files/", __FILE__)
 
@@ -35,11 +35,6 @@ module TablexiDev
         unless File.exist?(".rubocop-project_overrides.yml") # rubocop:disable Style/GuardClause
           copy_file "dot_rubocop-project_overrides.yml", ".rubocop-project_overrides.yml"
         end
-      end
-
-      def copy_and_set_executable(source_file, target_file)
-        copy_file source_file, target_file
-        chmod target_file, 0o755
       end
 
     end

--- a/lib/generators/tablexi_dev/unicorn_generator.rb
+++ b/lib/generators/tablexi_dev/unicorn_generator.rb
@@ -4,7 +4,7 @@ module TablexiDev
 
   module Generators
 
-    class UnicornGenerator < Rails::Generators::Base
+    class UnicornGenerator < BaseGenerator
 
       source_root File.expand_path("../unicorn_generator/templates", __FILE__)
 


### PR DESCRIPTION
All of our `TablexiDev::FooGenerator`s now inherit from a `BaseGenerator` - where our shared generator code can live.   Also fixed the `GitHookGenerator` so generates executable files.