### PR TITLE
Fix 'could not load generator' errors

### DIFF
--- a/lib/generators/tablexi_dev/all_generator.rb
+++ b/lib/generators/tablexi_dev/all_generator.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative './base_generator'
+
 module TablexiDev
 
   module Generators

--- a/lib/generators/tablexi_dev/git_hook_generator.rb
+++ b/lib/generators/tablexi_dev/git_hook_generator.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative './base_generator'
+
 module TablexiDev
 
   module Generators

--- a/lib/generators/tablexi_dev/rubocop_generator.rb
+++ b/lib/generators/tablexi_dev/rubocop_generator.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative './base_generator'
+
 module TablexiDev
 
   module Generators

--- a/lib/generators/tablexi_dev/unicorn_generator.rb
+++ b/lib/generators/tablexi_dev/unicorn_generator.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative './base_generator'
+
 module TablexiDev
 
   module Generators


### PR DESCRIPTION
In version 0.1.2, I ran into an issue where I was getting the error `Could not load generator "generators/tablexi_dev/rubocop_generator`.

Here's the stack trace:

```
➜  push-customer-portal git:(develop) ✗ bin/rails g tablexi_dev:rubocop
Running via Spring preloader in process 75816
/Users/tablexi/Code/push-customer-portal/spec/factories/measurements.rb:29: warning: already initialized constant TYPE_UNITS
/Users/tablexi/Code/push-customer-portal/spec/factories/measurements.rb:29: warning: previous definition of TYPE_UNITS was here
[WARNING] Could not load generator "generators/tablexi_dev/rubocop_generator". Error: uninitialized constant TablexiDev::Generators::BaseGenerator.
/Users/tablexi/Code/tablexi_dev-generators/lib/generators/tablexi_dev/rubocop_generator.rb:7:in `<module:Generators>'
/Users/tablexi/Code/tablexi_dev-generators/lib/generators/tablexi_dev/rubocop_generator.rb:5:in `<module:TablexiDev>'
/Users/tablexi/Code/tablexi_dev-generators/lib/generators/tablexi_dev/rubocop_generator.rb:3:in `<top (required)>'
/Users/tablexi/.rvm/gems/ruby-2.4.3/gems/railties-5.1.6/lib/rails/command/behavior.rb:82:in `block (2 levels) in lookup'
/Users/tablexi/.rvm/gems/ruby-2.4.3/gems/railties-5.1.6/lib/rails/command/behavior.rb:78:in `each'
/Users/tablexi/.rvm/gems/ruby-2.4.3/gems/railties-5.1.6/lib/rails/command/behavior.rb:78:in `block in lookup'
/Users/tablexi/.rvm/gems/ruby-2.4.3/gems/railties-5.1.6/lib/rails/command/behavior.rb:77:in `each'
/Users/tablexi/.rvm/gems/ruby-2.4.3/gems/railties-5.1.6/lib/rails/command/behavior.rb:77:in `lookup'
```