### PR TITLE
Allow Rails 3.2

### DIFF
--- a/tablexi_dev-generators.gemspec
+++ b/tablexi_dev-generators.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
-  s.add_dependency "rails", ">= 4.0"
+  s.add_dependency "rails", ">= 3.2"
 
   s.add_development_dependency "rubocop"
   s.add_development_dependency "sqlite3"


### PR DESCRIPTION
Errors coming from the dummy app prevent the specs from running with Rails 3.2 (`NoMethodError` on `Rails::Application::Configuration#load_defaults` and `Rails::Application#configure`). However, the generators work as expected in Frommers, which is on Rails 3.2. I could understand not wanting to support a Rails version that doesn't work with the specs, but the gem is usable in practice. Might as well allow it?